### PR TITLE
Switch to 3D bar traces

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
 
   <script>
   /*****************************************************************************************
-   * Plot3D component – wraps Plotly 3-D scatter plot with a loading overlay                *
+   * Plot3D component – wraps Plotly 3-D bar plot with a loading overlay                *
    *****************************************************************************************/
   const Plot3D = {
     props: {
@@ -68,7 +68,7 @@
         // Prepare layout dynamically based on props
         const { traces, categories, ySpacing } = props.plotData;
         const layout = {
-          title: 'Optical Properties 3D Plot', autosize: true,
+          title: 'Optical Properties 3D Bar Plot', autosize: true,
           paper_bgcolor: '#fff', plot_bgcolor: '#fff', margin: { l: 0, r: 0, b: 0, t: 40 },
           legend: { orientation: 'v', x: 0.02, y: 0.98, xanchor: 'left', bgcolor: 'rgba(255,255,255,0.6)', bordercolor: '#ccc' },
           scene: {
@@ -227,11 +227,9 @@
             x: rows.map(r => r.wavelength),
             y: Array(rows.length).fill(yVal),
             z: rows.map(r => r[zMetric]),
-            mode: 'lines+markers',
             name: material,
-            type: 'scatter3d',
-            marker: { size: 4, color },
-            line: { color, width: 2 }
+            type: 'bar3d',
+            marker: { color }
           };
         });
 


### PR DESCRIPTION
## Summary
- switch Plot3D component back to 3D layout
- output `bar3d` traces instead of scatter markers and lines
- update component docs and plot title

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861bd8da13c832aba66ef3bd6ecaed7